### PR TITLE
Disallow depositing in wrong contracts in Alux when in OP

### DIFF
--- a/packages/nextjs/app/cdp/components/CDPStats.tsx
+++ b/packages/nextjs/app/cdp/components/CDPStats.tsx
@@ -72,11 +72,13 @@ const CDPStats: React.FC = () => {
   const assetNames = Object.keys(config.houseOfReserves);
 
   useEffect(() => {
-    if (houseOfReserveData) {
-      console.log("House of Reserve Data:", houseOfReserveData);
-    }
-    if (houseOfReserveError) {
-      console.error("Error fetching house of reserve data:", houseOfReserveError);
+    if (process.env.NODE_ENV === "development") {
+      if (houseOfReserveData) {
+        console.log("House of Reserve Data:", houseOfReserveData);
+      }
+      if (houseOfReserveError) {
+        console.error("Error fetching house of reserve data:", houseOfReserveError);
+      }
     }
   }, [houseOfReserveData, houseOfReserveError]);
 

--- a/packages/nextjs/app/cdp/components/tables/YourDeposits.tsx
+++ b/packages/nextjs/app/cdp/components/tables/YourDeposits.tsx
@@ -218,23 +218,19 @@ const YourDeposits = () => {
   });
 
   useEffect(() => {
-    if (batchCheckRemainingMintingPower) {
-      console.log("Batch CheckRemainingMintingPower:", batchCheckRemainingMintingPower);
-    }
-    if (isError) {
-      console.error("Error fetching checkRemainingMintingPower:", isError);
+    if (process.env.NODE_ENV === "development") {
+      if (batchCheckRemainingMintingPower) {
+        console.log("Batch CheckRemainingMintingPower:", batchCheckRemainingMintingPower);
+      }
+      if (isError) {
+        console.error("Error fetching checkRemainingMintingPower:", isError);
+      }
     }
   }, [batchCheckRemainingMintingPower, isError]);
 
   const { data: batchComputeUserHealthRatio } = useReadContracts({
     contracts: batchComputeUserHealthRatioArray,
   });
-
-  useEffect(() => {
-    if (batchComputeUserHealthRatio) {
-      console.log("BatchComputeUserHealthRatio:", batchComputeUserHealthRatio);
-    }
-  }, [batchComputeUserHealthRatio]);
 
   const [isMintModalOpen, setIsMintModalOpen] = useState(false);
   const [isRepayModalOpen, setIsRepayModalOpen] = useState(false);
@@ -316,10 +312,6 @@ const YourDeposits = () => {
   const formattedUserHealthRatio: any[] = batchComputeUserHealthRatio
     ? batchComputeUserHealthRatio.map(({ result }) => (Number(result) / 10 ** 18).toFixed(2))
     : [0, 0, 0, 0, 0];
-
-  // console.log("batchBalances:", batchDeposits);
-  // console.log("Formatted batchBalances", formattedBalances);
-  // console.log("batchMints:", batchMints);
 
   const deposits = generateDeposits(
     contractData,

--- a/packages/nextjs/app/lending/components/ProfileStats.tsx
+++ b/packages/nextjs/app/lending/components/ProfileStats.tsx
@@ -21,8 +21,8 @@ const ProfileStats: React.FC<ProfileStatsProps> = ({ balance, netAPY, healthFact
 
   // Function to get network error message based on chainId
   const getNetworkErrorMessage = () => {
-    if (chainId === 56 || chainId === 137) {
-      return t("WrongNetworkMessage"); // Replace with your translation key
+    if (chainId !== 8453) {
+      return t("WrongNetworkMessage");
     }
     return null;
   };
@@ -33,7 +33,7 @@ const ProfileStats: React.FC<ProfileStatsProps> = ({ balance, netAPY, healthFact
     <header className="bg-inherit dark:bg-inherit flex flex-col space-y-2 w-full md:w-fit">
       <div>
         {networkErrorMessage ? (
-          <div className="text-2xl text-red-600 font-bold">Wrong network, change to the Base network!</div>
+          <div className="text-2xl text-red-600 font-bold">Wrong network, please change to the Base network!</div>
         ) : (
           <div className="flex items-center space-x-2 mb-2">
             <div className="text-2xl">

--- a/packages/nextjs/app/lending/page.tsx
+++ b/packages/nextjs/app/lending/page.tsx
@@ -16,6 +16,7 @@ import useGetUserAccountData from "@/hooks/useGetUserAccountData";
 import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { maxUint256 } from "viem";
+import { useChainId } from "wagmi";
 import { ReserveData } from "~~/types/types";
 
 // Importa el hook de datos del usuario
@@ -36,6 +37,8 @@ const Lending = () => {
 
   const { address } = useAccountAddress(); // Obtén la dirección del usuario
   const { userAccountData, isLoading, isError } = useGetUserAccountData(address || ""); // Obtén los datos del usuario
+
+  const chainId = useChainId();
 
   const refreshComponents = () => {
     setRefreshKey(prevKey => prevKey + 1);
@@ -63,6 +66,16 @@ const Lending = () => {
     );
   };
 
+  // Function to get network error message based on chainId
+  const getNetworkErrorMessage = () => {
+    if (chainId !== 8453) {
+      return t("WrongNetworkMessage");
+    }
+    return null;
+  };
+
+  const networkErrorMessage = getNetworkErrorMessage();
+
   const formattedHealthFactor = userAccountData?.healthFactor
     ? isMaxUint256(userAccountData.healthFactor)
       ? "∞"
@@ -71,129 +84,139 @@ const Lending = () => {
 
   return (
     <div className="flex flex-col w-4/5 m-auto gap-4">
-      <div className="lending-header flex bg-white rounded-xl py-6 px-8 justify-between items-end">
-        {isLoading ? (
-          <div>Loading...</div>
-        ) : isError ? (
-          <div>Error loading data</div>
-        ) : (
-          <ProfileStats
-            balance={netWorth}
-            netAPY={userAccountData?.ltv || 0} // Usa datos del hook de usuario para APY o cualquier otro campo relevante
-            healthFactor={formattedHealthFactor} // Usa datos del hook de usuario para el health factor
-          />
-        )}
-        <button onClick={refreshComponents} className="primary-btn h-fit w-fit">
-          {t("LendingRefreshButton")}
-        </button>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="flex flex-col gap-4">
-          {/* Your Supplies */}
-          <div className="table-background rounded-xl p-8 flex flex-col">
-            <div className="flex justify-between items-center">
-              <div>
-                <h1 className="text-primary">{t("LendingYourSuppliesTitle")}</h1>
-              </div>
-              <button
-                onClick={() => setIsYourSuppliesVisible(prev => !prev)}
-                className="text-primary focus:outline-none"
-              >
-                {isYourSuppliesVisible ? (
-                  <FontAwesomeIcon icon={faChevronUp} />
-                ) : (
-                  <FontAwesomeIcon icon={faChevronDown} />
-                )}
-              </button>
-            </div>
-            {isYourSuppliesVisible && (
-              <YourSupplies
-                setAllBalancesZero={setAllBalancesZero}
-                setSuppliesTotalBalance={setSuppliesTotalBalance}
-                key={refreshKey}
+      {networkErrorMessage ? (
+        <div className="min-h-36 text-center bg-white rounded-xl py-6 px-8 mt-4 flex items-center justify-center">
+          <p className="text-2xl text-red-600 font-bold">Wrong network, please change to the Base network!</p>
+        </div>
+      ) : (
+        <>
+          <div className="min-h-flex bg-white rounded-xl py-6 px-8 justify-between items-end">
+            {isLoading ? (
+              <div>Loading...</div>
+            ) : isError ? (
+              <div>Error loading data</div>
+            ) : (
+              <ProfileStats
+                balance={netWorth}
+                netAPY={userAccountData?.ltv || 0} // Usa datos del hook de usuario para APY o cualquier otro campo relevante
+                healthFactor={formattedHealthFactor} // Usa datos del hook de usuario para el health factor
               />
             )}
+            <button onClick={refreshComponents} className="primary-btn h-fit w-fit">
+              {t("LendingRefreshButton")}
+            </button>
           </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex flex-col gap-4">
+              {/* Your Supplies */}
+              <div className="table-background rounded-xl p-8 flex flex-col">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <h1 className="text-primary">{t("LendingYourSuppliesTitle")}</h1>
+                  </div>
+                  <button
+                    onClick={() => setIsYourSuppliesVisible(prev => !prev)}
+                    className="text-primary focus:outline-none"
+                  >
+                    {isYourSuppliesVisible ? (
+                      <FontAwesomeIcon icon={faChevronUp} />
+                    ) : (
+                      <FontAwesomeIcon icon={faChevronDown} />
+                    )}
+                  </button>
+                </div>
+                {isYourSuppliesVisible && (
+                  <YourSupplies
+                    setAllBalancesZero={setAllBalancesZero}
+                    setSuppliesTotalBalance={setSuppliesTotalBalance}
+                    key={refreshKey}
+                  />
+                )}
+              </div>
 
-          {/* Assets to Supply */}
-          <div className="table-background rounded-xl p-8 flex flex-col">
-            <div className="flex justify-between items-center">
-              <div>
-                <h1 className="text-primary">{t("LendingAssetsToSupplyTitle")}</h1>
-                {isAssetsToSupplyVisible && (
-                  <p className="subtitles-gray-color">{t("LendingAssetsToSupplyDescription")}</p>
-                )}
+              {/* Assets to Supply */}
+              <div className="table-background rounded-xl p-8 flex flex-col">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <h1 className="text-primary">{t("LendingAssetsToSupplyTitle")}</h1>
+                    {isAssetsToSupplyVisible && (
+                      <p className="subtitles-gray-color">{t("LendingAssetsToSupplyDescription")}</p>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => setIsAssetsToSupplyVisible(prev => !prev)}
+                    className="text-primary focus:outline-none"
+                  >
+                    {isAssetsToSupplyVisible ? (
+                      <FontAwesomeIcon icon={faChevronUp} />
+                    ) : (
+                      <FontAwesomeIcon icon={faChevronDown} />
+                    )}
+                  </button>
+                </div>
+                {isAssetsToSupplyVisible && <AssetsToSupply key={refreshKey} onReserveClick={handleReserveClick} />}
               </div>
-              <button
-                onClick={() => setIsAssetsToSupplyVisible(prev => !prev)}
-                className="text-primary focus:outline-none"
-              >
-                {isAssetsToSupplyVisible ? (
-                  <FontAwesomeIcon icon={faChevronUp} />
-                ) : (
-                  <FontAwesomeIcon icon={faChevronDown} />
-                )}
-              </button>
             </div>
-            {isAssetsToSupplyVisible && <AssetsToSupply key={refreshKey} onReserveClick={handleReserveClick} />}
-          </div>
-        </div>
 
-        <div className="flex flex-col gap-4">
-          {/* Your Borrows */}
-          <div className="table-background rounded-xl p-8 flex flex-col">
-            <div className="flex justify-between items-center">
-              <div>
-                <h1 className="text-primary">{t("LendingYourBorrowsTitle")}</h1>
-              </div>
-              <button
-                onClick={() => setIsYourBorrowsVissible(prev => !prev)}
-                className="text-primary focus:outline-none"
-              >
-                {isYourBorrowsVissible ? (
-                  <FontAwesomeIcon icon={faChevronUp} />
-                ) : (
-                  <FontAwesomeIcon icon={faChevronDown} />
+            <div className="flex flex-col gap-4">
+              {/* Your Borrows */}
+              <div className="table-background rounded-xl p-8 flex flex-col">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <h1 className="text-primary">{t("LendingYourBorrowsTitle")}</h1>
+                  </div>
+                  <button
+                    onClick={() => setIsYourBorrowsVissible(prev => !prev)}
+                    className="text-primary focus:outline-none"
+                  >
+                    {isYourBorrowsVissible ? (
+                      <FontAwesomeIcon icon={faChevronUp} />
+                    ) : (
+                      <FontAwesomeIcon icon={faChevronDown} />
+                    )}
+                  </button>
+                </div>
+                {isYourBorrowsVissible && (
+                  <YourBorrows setBorrowsTotalBalance={setBorrowsTotalBalance} key={refreshKey} />
                 )}
-              </button>
-            </div>
-            {isYourBorrowsVissible && <YourBorrows setBorrowsTotalBalance={setBorrowsTotalBalance} key={refreshKey} />}
-          </div>
-          {/* Assets to Borrow */}
-          <div className="table-background rounded-xl p-8 flex flex-col">
-            <div className="flex justify-between items-center">
-              <div>
-                <h1 className="text-primary">{t("LendingAssetsToBorrowTitle")}</h1>
-                {isAssetsToBorrowVisible && !allBalancesZero && (
-                  <p className="subtitles-gray-color">{t("LendingAssetsToBorrowDescription")}</p>
-                )}
-                {allBalancesZero && <p className="subtitles-gray-color">{t("LendingAssetsToBorrowZeroBalance")}</p>}
               </div>
-              {!allBalancesZero && (
-                <button
-                  onClick={() => setIsAssetsToBorrowVisible(prev => !prev)}
-                  className="text-primary focus:outline-none"
-                >
-                  {isAssetsToBorrowVisible ? (
-                    <FontAwesomeIcon icon={faChevronUp} />
-                  ) : (
-                    <FontAwesomeIcon icon={faChevronDown} />
+              {/* Assets to Borrow */}
+              <div className="table-background rounded-xl p-8 flex flex-col">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <h1 className="text-primary">{t("LendingAssetsToBorrowTitle")}</h1>
+                    {isAssetsToBorrowVisible && !allBalancesZero && (
+                      <p className="subtitles-gray-color">{t("LendingAssetsToBorrowDescription")}</p>
+                    )}
+                    {allBalancesZero && <p className="subtitles-gray-color">{t("LendingAssetsToBorrowZeroBalance")}</p>}
+                  </div>
+                  {!allBalancesZero && (
+                    <button
+                      onClick={() => setIsAssetsToBorrowVisible(prev => !prev)}
+                      className="text-primary focus:outline-none"
+                    >
+                      {isAssetsToBorrowVisible ? (
+                        <FontAwesomeIcon icon={faChevronUp} />
+                      ) : (
+                        <FontAwesomeIcon icon={faChevronDown} />
+                      )}
+                    </button>
                   )}
-                </button>
-              )}
+                </div>
+                {isAssetsToBorrowVisible && !allBalancesZero && <AssetsToBorrow key={refreshKey} />}
+              </div>
             </div>
-            {isAssetsToBorrowVisible && !allBalancesZero && <AssetsToBorrow key={refreshKey} />}
           </div>
-        </div>
-      </div>
-      <div className="flex flex-col lg:flex-row gap-4">
-        <div className="w-full lg:w-1/2">
-          {selectedReserveAsset && <ReserveAssetInfo reserve={selectedReserveAsset} />}
-        </div>
-        <div className="w-full lg:w-1/2">
-          <LendingInfo />
-        </div>
-      </div>
+          <div className="flex flex-col lg:flex-row gap-4">
+            <div className="w-full lg:w-1/2">
+              {selectedReserveAsset && <ReserveAssetInfo reserve={selectedReserveAsset} />}
+            </div>
+            <div className="w-full lg:w-1/2">
+              <LendingInfo />
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/nextjs/app/liquidity/components/LiquidityInfo/index.tsx
+++ b/packages/nextjs/app/liquidity/components/LiquidityInfo/index.tsx
@@ -12,7 +12,7 @@ const LiquidityInfo: React.FC = () => {
   const chainId = useChainId();
   // Function to get network error message based on chainId
   const getNetworkErrorMessage = () => {
-    if (chainId === 56 || chainId === 137) {
+    if (chainId !== 8453) {
       return t("WrongNetworkMessage"); // Replace with your translation key
     }
     return null;

--- a/packages/nextjs/app/liquidity/components/LiquidityWidget/index.tsx
+++ b/packages/nextjs/app/liquidity/components/LiquidityWidget/index.tsx
@@ -269,7 +269,7 @@ const LiquidityWidget: React.FC = () => {
   };
 
   // Modify the button style and text based on chainId
-  const isWrongNetwork = chainId === 56 || chainId === 137;
+  const isWrongNetwork = chainId !== 8453;
   const buttonLabel = approvalLoading
     ? t("Processing...") // Show "Processing" when loading
     : isWrongNetwork

--- a/packages/nextjs/app/liquidity/components/OverviewWidget/index.tsx
+++ b/packages/nextjs/app/liquidity/components/OverviewWidget/index.tsx
@@ -42,7 +42,7 @@ const OverviewWidget: React.FC = () => {
 
   // Function to get network error message based on chainId
   const getNetworkErrorMessage = () => {
-    if (chainId === 56 || chainId === 137) {
+    if (chainId !== 8453) {
       return t("WrongNetworkMessage"); // Replace with your translation key
     }
     return null;

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -12,8 +12,6 @@ export const enabledChains = targetNetworks.find((network: Chain) => network.id 
   ? targetNetworks
   : ([...targetNetworks, mainnet] as const);
 
-console.log("Enabled Chains:", enabledChains);
-
 export const wagmiConfig = createConfig({
   chains: enabledChains,
   connectors: wagmiConnectors,


### PR DESCRIPTION
Lo más importante de este fix, la razón por la que no desplegaba error en OP, la condición era:
Si estás en Polygon o BSC muestra error...y como yo estaba en OP no me mostró error, y pude mandar dinero a un contrato incorrecto:
```
if (chainId === 56 || chainId === 137) {
      return t("WrongNetworkMessage")
```
      
Lo cambié por: "si no estás en Base, tira error" y lo cambié en todos lados donde aparecía esta condición.

Además hice el display inmediato al nivel de la página de /lending si estás en la wrong network, ya que antes se seguía mostrando los botones de Supply y otra info en otros componentes.

![Screenshot 2025-05-20 200043](https://github.com/user-attachments/assets/aae7e56a-dec2-49fc-a119-346d8e620292)

![Screenshot 2025-05-20 200024](https://github.com/user-attachments/assets/f892f3e2-a6a2-44bb-a353-eebeb4b1ad7a)
