### PR TITLE
fix(lending): Fix empty stats and data after network switch

### DIFF
--- a/packages/nextjs/app/lending/page.tsx
+++ b/packages/nextjs/app/lending/page.tsx
@@ -54,6 +54,15 @@ const Lending = () => {
 
   const chainId = useChainId();
 
+  // ==========================================================
+  // == PERBAIKAN: REFRESH OTOMATIS SAAT GANTI JARINGAN ==
+  // ==========================================================
+  useEffect(() => {
+    console.log("Network changed, refreshing components...");
+    refreshComponents();
+  }, [chainId, refreshComponents]);
+  // ==========================================================
+
   // Function to get network error message based on chainId
   const getNetworkErrorMessage = () => {
     if (chainId !== 8453) {


### PR DESCRIPTION
This PR fixes issue #122.

**Problem:**
The user profile stats and other data on the lending page become empty or do not update after switching the wallet's network. This happens because the data-fetching hooks use a hardcoded chainId.

**Solution:**
1.  Updated the data-fetching hooks (`useGetUserAccountData`, `useGetReservesData`, etc.) to use the dynamic `targetNetwork.id` instead of a hardcoded value.
2.  Added a `useEffect` hook to the main `Lending` page component. This hook watches for changes in `chainId` and triggers a component refresh to re-fetch all necessary data.

**How to test:**
1.  Go to the lending page while connected to the Base network.
2.  Observe the profile stats.
3.  Switch your wallet's network to another one (e.g., a testnet or any other EVM chain).
4.  The profile stats should now correctly appear empty or as zero, without getting stuck.
5.  Switch back to the Base network, and the stats should reappear correctly.

Closes #122